### PR TITLE
feat(wss): expose WebsocketServer as a context prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ function createWebsocketMiddleware (propertyName = 'ws', options) {
         wss.handleUpgrade(ctx.req, ctx.request.socket, Buffer.alloc(0), resolve)
         ctx.respond = false
       })
+      ctx.wss = wss;
     }
 
     await next()


### PR DESCRIPTION
Related to this https://github.com/sibelius/graphql-ws-multiserver/pull/1/files#diff-841254fe75488c1bd4cd7f68f00b4be0e48dcfbc4a16b45847b68295e0e3b27bR78

I need to pass the WebSocket server to https://github.com/enisdenjo/graphql-transport-ws to let it handle sockets messages

so I need to handle upgrade myself in user land