### PR TITLE
Add a connection event trigger

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,10 @@ function createWebsocketMiddleware (propertyName = 'ws', options) {
     if (~upgradeHeader.indexOf('websocket')) {
       debug(`websocket middleware in use on route ${ctx.path}`)
       ctx[propertyName] = () => new Promise((resolve) => {
-        wss.handleUpgrade(ctx.req, ctx.request.socket, Buffer.alloc(0), resolve)
+        wss.handleUpgrade(ctx.req, ctx.request.socket, Buffer.alloc(0), (ws)=>{
+          resolve(ws)
+          wss.emit('connection', ws, ctx.req)
+        })
         ctx.respond = false
       })
     }


### PR DESCRIPTION
Hi, when I used the [ws-heart](https://www.npmjs.com/package/ws-heartbeat) library, I found that it did not achieve the expected effect. After checking, I found that the `connection` event needs to be triggered to work properly, so I have this pull request.