### PR TITLE
Fix TypeScript definition errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,16 +2,17 @@ import WebSocket, { ServerOptions } from "ws";
 import http from "http";
 import { Middleware } from "koa";
 
-export type WebSocketContext<PropertyName extends string = "ws", ServerPropertyName extends string> = {
-  [PropertyName]?: () => Promise<WebSocket>;
-  [ServerPropertyName]?: WebSocket.Server;
-};
+export type WebSocketContext<PropertyName extends string = "ws", ServerPropertyName extends string | never = never> = {
+    [K in PropertyName]?: () => Promise<WebSocket>;
+  } & {
+    [K in ServerPropertyName]?: WebSocket.Server;
+  };
 
 export type WebSocketMiddleware = {
   server: WebSocket.Server;
 };
 
-declare function websocket<PropertyName extends string = "ws", ServerPropertyName extends string>(
+declare function websocket<PropertyName extends string = "ws", ServerPropertyName extends string | never = never>(
   propertyName?: PropertyName,
   options?: { server?: http.Server; wsOptions?: ServerOptions, exposeServerOn?: ServerPropertyName }
 ): Middleware<{}, WebSocketContext<PropertyName, ServerPropertyName>> & WebSocketMiddleware;


### PR DESCRIPTION
Current TypeScript definitions do not compile:
> ../../node_modules/koa-easy-ws/index.d.ts(5,66): error TS2706: Required type parameters may not follow optional type parameters. 
> ../../node_modules/koa-easy-ws/index.d.ts(6,3): error TS1170: A computed property name in a type literal must refer to an expression whose type is a literal type or a 'unique symbol' type. 
> ../../node_modules/koa-easy-ws/index.d.ts(6,4): error TS2693: 'PropertyName' only refers to a type, but is being used as a value here. 
> ../../node_modules/koa-easy-ws/index.d.ts(7,3): error TS1170: A computed property name in a type literal must refer to an expression whose type is a literal type or a 'unique symbol' type. 
> ../../node_modules/koa-easy-ws/index.d.ts(7,4): error TS2693: 'ServerPropertyName' only refers to a type, but is being used as a value here.
> ../../node_modules/koa-easy-ws/index.d.ts(14,64): error TS2706: Required type parameters may not follow optional type parameters.

This change fixes all of these errors.